### PR TITLE
[IMP] mail_debrand: keep the decoration (grey border) where the branding was

### DIFF
--- a/mail_debrand/models/mail_render_mixin.py
+++ b/mail_debrand/models/mail_render_mixin.py
@@ -41,9 +41,9 @@ class MailRenderMixin(models.AbstractModel):
                 # Remove "Powered by", "using" etc.
                 previous = elem.getprevious()
                 if previous is not None:
-                    previous.tail = ""
+                    previous.tail = etree.CDATA("&nbsp;")
                 elif parent.text:
-                    parent.text = ""
+                    parent.text = etree.CDATA("&nbsp;")
                 parent.remove(elem)
             value = etree.tostring(
                 tree, pretty_print=True, method="html", encoding="unicode"


### PR DESCRIPTION
Before:
![image](https://github.com/EmesaDEV/oca-social/assets/1033124/6dd9e9c5-cd51-4bda-a64c-ce94c5435dba)

After:
![image](https://github.com/EmesaDEV/oca-social/assets/1033124/782db765-4fbe-4b7f-a705-c73260f2d377)
